### PR TITLE
fix: iPhone notch safe-area color change and minor padding clean up

### DIFF
--- a/src/components/layout/GlobalStyles.js
+++ b/src/components/layout/GlobalStyles.js
@@ -50,9 +50,9 @@ export default function GlobalStyles() {
           top: 0;
           left: 0;
           right: 0;
-          bottom: 0;
+          height: env(safe-area-inset-top);
           background: #0a0a0a;
-          z-index: -1;
+          z-index: 9999;
           pointer-events: none;
         }
       }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -175,6 +175,7 @@ export default function Blog() {
                         margin: "0 0 20px 0",
                         lineHeight: "1.6 !important",
                         fontWeight: "400 !important",
+                        fontFamily: "'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important",
                         display: "-webkit-box",
                         WebkitLineClamp: "3",
                         WebkitBoxOrient: "vertical",
@@ -318,7 +319,7 @@ export default function Blog() {
         }
 
         .post-content {
-          padding: 24px;
+          padding: 20px;
         }
 
         .post-meta {
@@ -345,6 +346,10 @@ export default function Blog() {
             margin: 0 10px;
           }
 
+          .post-content {
+            padding: 18px;
+          }
+
           .hero-section {
             padding: 35px 0 30px 0;
           }
@@ -364,7 +369,7 @@ export default function Blog() {
           }
 
           .post-content {
-            padding: 20px;
+            padding: 16px;
           }
 
           .hero-section {


### PR DESCRIPTION
Blog/BTS styling consistency:

- Matched tag styling between blog and episode cards
- Aligned thumbnail sizes (240px height)
- Matched padding and spacing throughout
- Fixed read-time/duration font sizes
- Matched description font type, size, color, and line height
- Aligned content padding (20px desktop, 18px tablet, 16px mobile)

Mobile experience fixes:

- Fixed iPhone safe area - notch area now black instead of white
- Resolved mobile scrolling issues on blog/BTS pages
- Added proper iOS scrolling behavior
