### PR TITLE
fix: safe-area ios color tweak in css

### DIFF
--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -6,12 +6,39 @@
         overflow-x: hidden !important;
         width: 100% !important;
         max-width: 100% !important;
-        /* Removed safe-area-inset padding for seamless background */
-        background: #ffffff !important;
+        /* iPhone Safe Area Support */
+        padding-top: env(safe-area-inset-top) !important;
+        padding-bottom: env(safe-area-inset-bottom) !important;
         margin: 0 !important;
-        padding: 0 !important;
         border: 0 !important;
         min-height: 100vh !important;
+    }
+
+    /* iPhone Safe Area Black Background */
+    @supports (padding: max(0px)) {
+        html::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: env(safe-area-inset-top);
+            background: #0a0a0a;
+            z-index: 99999;
+            pointer-events: none;
+        }
+        
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: env(safe-area-inset-top);
+            background: #0a0a0a;
+            z-index: 99999;
+            pointer-events: none;
+        }
     }
 
     /* Container fixes to prevent overflow */

--- a/src/components/layout/GlobalStyles.js
+++ b/src/components/layout/GlobalStyles.js
@@ -22,13 +22,43 @@ export default function GlobalStyles() {
         -webkit-overflow-scrolling: touch;
       }
 
-      /* iPhone Safe Area Support */
+      /* iPhone Safe Area Support - Global */
       @supports (padding: max(0px)) {
-        body {
-          padding-left: env(safe-area-inset-left);
-          padding-right: env(safe-area-inset-right);
+        html {
           padding-top: env(safe-area-inset-top);
           padding-bottom: env(safe-area-inset-bottom);
+        }
+        
+        body {
+          padding-top: env(safe-area-inset-top);
+          padding-bottom: env(safe-area-inset-bottom);
+        }
+      }
+
+      /* Global Safe Area Black Background */
+      @supports (padding: max(0px)) {
+        html::before {
+          content: '';
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: env(safe-area-inset-top);
+          background: #0a0a0a;
+          z-index: 99999;
+          pointer-events: none;
+        }
+        
+        body::before {
+          content: '';
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: env(safe-area-inset-top);
+          background: #0a0a0a;
+          z-index: 99999;
+          pointer-events: none;
         }
       }
 


### PR DESCRIPTION
✅ Top safe area (notch): Black background with proper padding
✅ Left/Right sides: No unwanted padding - content uses full width
✅ Bottom safe area: Proper padding for home indicator
✅ All pages: Consistent behavior across your entire website